### PR TITLE
Allow deeplinking to individual slides

### DIFF
--- a/resources/site.jinja
+++ b/resources/site.jinja
@@ -26,7 +26,9 @@
               <img src="{{ s['image'] }}" />
             </td>
             <td class="note">
+              <a name="{{ loop.index }}"></a>
               {{ s['note'] | replace('\n', '<br />') }}
+              <a href="#{{ loop.index }}">#</a>
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
Loved your presentation on [The Push Train](http://pushtrain.club/), and I wanted to reference some parts of it in a discussion with a colleague, but couldn't find a way to link to individual slides. This change will add an anchor to each slide, and will place a link at the end of each note that can be used to reference that specific slide. Hope you'll find this useful, thanks again for making those slides public!