### PR TITLE
make sure to sort slide .jpgs

### DIFF
--- a/export.py
+++ b/export.py
@@ -43,7 +43,7 @@ class Options(object):
 
 
 def slides_and_notes(opts, notes):
-    return zip(glob('%s/*jpeg' % opts.slidesdir), notes)
+    return zip(sorted(glob('%s/*jpeg' % opts.slidesdir)), notes)
 
 
 def make_dirs(opts):


### PR DESCRIPTION
`export.py` worked great -- except `glob` seems to [return pathnames in an arbitrary order](https://docs.python.org/3.6/library/glob.html) and that won't do for zipping together slides + presenter notes. :)