### PR TITLE
Skip presenter notes on skipped slides, too

### DIFF
--- a/export.py
+++ b/export.py
@@ -3,6 +3,7 @@ import appscript
 from argparse import ArgumentParser
 from contextlib import closing
 from glob import glob
+import itertools
 from jinja2 import Environment, FileSystemLoader
 import math
 import os
@@ -101,6 +102,8 @@ def export_keynote(filename, opts):
 
     with closing(keynote.open(keynote_file)) as doc:
         notes = doc.slides.presenter_notes()
+        skipped = doc.slides.skipped()
+        notes = list(itertools.compress(notes, [not s for s in skipped]))
 
         doc.export(as_=k.slide_images, to=outpath, with_properties = {
             k.export_style: k.IndividualSlides,


### PR DESCRIPTION
Fixes https://github.com/mcfunley/better-keynote-export/issues/3

We're pulling all presenter notes while exporting only the non-skipped slide images (`k.skipped_slides: False`)

With a Keynote file like:
![screen recording 2018-05-29 at 10 35 pm](https://user-images.githubusercontent.com/188595/40700986-f4cb336a-6390-11e8-8c9c-81f80cd2b91b.gif)

Before:
<img width="609" alt="before" src="https://user-images.githubusercontent.com/188595/40700970-e5137cac-6390-11e8-98b1-f073fcc442ac.png">

After:
<img width="625" alt="after" src="https://user-images.githubusercontent.com/188595/40700975-e8c11760-6390-11e8-9bb9-7340adb4ff61.png">
