### PR TITLE
Update reportlab dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 appscript==1.0.1
 Jinja2==2.9.6
 MarkupSafe==1.0
-reportlab==3.0
+reportlab==3.6.1


### PR DESCRIPTION
Thanks for making this project!

Clang would fail to compile when "pip installing" on my macbook until I updated to a more recent version, so I've just updated that dependency.

If it helps, I'm on a macbook from 2015, running OS X 11.5.2 , and I was using python 3.8.2 (my default system python - no other reason for using it), and pip 19.2.3, and Apple Keynote version 11.1 (7031.0.102).